### PR TITLE
Check sys.boot_completed instead of init.svc.bootanim

### DIFF
--- a/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
+++ b/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
@@ -310,7 +310,7 @@ private fun waitForEmulatorToFinishBoot(
                                     adb,
                                     "-s", emulator.id,
                                     "shell",
-                                    "getprop", "init.svc.bootanim"
+                                    "getprop", "sys.boot_completed"
                             ),
                             timeout = 10 to SECONDS,
                             redirectOutputTo = outputDirectory(args),
@@ -318,9 +318,9 @@ private fun waitForEmulatorToFinishBoot(
                     )
                             .filter { it is Notification.Exit }
                             .cast(Notification.Exit::class.java)
-                            .map { it.output.readText().contains("stopped", ignoreCase = true) }
-                            .switchMap { bootAnimationStopped ->
-                                if (bootAnimationStopped) {
+                            .map { it.output.readText().contains("1", ignoreCase = true) }
+                            .switchMap { bootCompleted ->
+                                if (bootCompleted) {
                                     Observable.just(targetEmulator)
                                 } else {
                                     Observable.never()


### PR DESCRIPTION
In my own testing, sys.boot_completed seems to be more reliable for the latest versions of the Android emulator that we're using.

ref: https://stackoverflow.com/questions/3634041/detect-when-android-emulator-is-fully-booted