### PR TITLE
 Poll for connected emulators before declaring successful stop

### DIFF
--- a/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
+++ b/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
@@ -143,6 +143,7 @@ fun stopAllEmulators(
         completableProcess: (List<String>, Pair<Int, TimeUnit>?) -> Completable = ::completableProcess
 ) {
     val startTime = System.nanoTime()
+    val timeoutTime = startTime + NANOSECONDS.convert(args.timeoutSeconds.toLong(), SECONDS)
 
     connectedEmulators()
             .map { emulators ->
@@ -159,6 +160,15 @@ fun stopAllEmulators(
             .doOnError { log("Error during stopping emulators, error = $it.") }
             .doOnCompleted { log("All emulators stopped.") }
             .await()
+
+    while (true) {
+        val emulators = connectedEmulators().toBlocking().value()
+        if (emulators.isEmpty()) {
+            break
+        } else if (System.nanoTime() > timeoutTime) {
+            throw TimeoutException("Timed out waiting for emulators to stop.")
+        }
+    }
 
     log("Swarmer: - \"My job is done here, took ${(System.nanoTime() - startTime).nanosAsSeconds()} seconds, bye bye.\"")
 }
@@ -347,7 +357,7 @@ private fun outputDirectory(args: Commands.Start) =
         }
 
 private fun connectedEmulators(): Single<Set<AdbDevice>> =
-        connectedAdbDevices().take(1).toSingle().map { it.filter { it.isEmulator }.toSet() }
+        connectedAdbDevicesNoModel().take(1).toSingle().map { it.filter { it.isEmulator }.toSet() }
 
 private fun createdEmulators(args: Commands.Start, timeout: Pair<Int, TimeUnit> = 60 to SECONDS): Single<Set<String>> =
         process(
@@ -363,3 +373,41 @@ private fun createdEmulators(args: Commands.Start, timeout: Pair<Int, TimeUnit> 
                             .map { it.trim() }
                             .toSet()
                 }
+
+private fun connectedAdbDevicesNoModel(): Observable<Set<AdbDevice>> = process(listOf(adb, "devices"), unbufferedOutput = true)
+    .ofType(Notification.Exit::class.java)
+    .map { it.output.readText() }
+    .map {
+        when (it.contains("List of devices attached")) {
+            true -> it
+            false -> throw IllegalStateException("Adb output is not correct: $it.")
+        }
+    }
+    .retry { retryCount, exception ->
+        val shouldRetry = retryCount < 5 && exception is IllegalStateException
+        if (shouldRetry) {
+            log("connectedAdbDevices: retrying $exception.")
+        }
+
+        shouldRetry
+    }
+    .flatMapIterable {
+        it
+            .substringAfter("List of devices attached")
+            .split(System.lineSeparator())
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .filter { it.contains("online") || it.contains("device") }
+    }
+    .map { line ->
+        val serial = line.substringBefore("\t")
+        val online = when {
+            line.contains("offline", ignoreCase = true) -> false
+            line.contains("device", ignoreCase = true) -> true
+            else -> throw IllegalStateException("Unknown adb output for device: $line")
+        }
+        AdbDevice(id = serial, online = online)
+    }
+    .toList()
+    .map { it.toSet() }
+    .doOnError { log("Error during getting connectedAdbDevices, error = $it") }

--- a/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
+++ b/swarmer/src/main/kotlin/com/gojuno/swarmer/Emulators.kt
@@ -163,10 +163,13 @@ fun stopAllEmulators(
 
     while (true) {
         val emulators = connectedEmulators().toBlocking().value()
+        val timeLeftMillis = System.nanoTime() - timeoutTime / 1000L
         if (emulators.isEmpty()) {
             break
-        } else if (System.nanoTime() > timeoutTime) {
+        } else if (timeLeftMillis <= 0L) {
             throw TimeoutException("Timed out waiting for emulators to stop.")
+        } else {
+            Thread.sleep(minOf(timeLeftMillis, 100L))
         }
     }
 

--- a/swarmer/src/test/kotlin/com/gojuno/swarmer/EmulatorsSpec.kt
+++ b/swarmer/src/test/kotlin/com/gojuno/swarmer/EmulatorsSpec.kt
@@ -32,7 +32,14 @@ class EmulatorsSpec : Spek({
     ).forEach { command ->
         describe("emulator stop called with timeout ${command.timeoutSeconds}") {
             val connectedEmulators by memoized {
-                { Single.just(ADB_DEVICES) }
+                var i = 0
+                {
+                    i += 1
+                    if (i % 2 == 1)
+                        Single.just(ADB_DEVICES)
+                    else
+                        Single.just(emptySet())
+                }
             }
             val startProcess by memoized {
                 mock<(List<String>, Pair<Int, TimeUnit>?) -> Completable>().apply {


### PR DESCRIPTION
The adb command (e.g. `adb -e emu kill`) to kill an emulator does not wait for the emulator to terminate before returning success.  So, let's poll and wait until all emulators are gone before declaring that the emulators actually stopped.